### PR TITLE
Skip callback if no detections

### DIFF
--- a/samples/v2/stream_detection_alerts.py
+++ b/samples/v2/stream_detection_alerts.py
@@ -395,7 +395,8 @@ def stream_detection_alerts(
         # a non-heartbeat detection batch.
         continuation_time = batch["continuationTime"]
         if "detections" not in batch:
-          _LOGGER_.info("Got a new continuation time, no detections")
+          _LOGGER_.info("Got a new continuationTime=%s, no detections",
+                        continuation_time)
           continue
         else:
           _LOGGER_.info("Got detection batch with continuationTime=%s",

--- a/samples/v2/stream_detection_alerts.py
+++ b/samples/v2/stream_detection_alerts.py
@@ -394,11 +394,15 @@ def stream_detection_alerts(
         # When we reach this line, we have successfully received
         # a non-heartbeat detection batch.
         continuation_time = batch["continuationTime"]
-        _LOGGER_.info("Got detection batch with continuationTime=%s",
-                      continuation_time)
+        if "detections" not in batch:
+          _LOGGER_.info("Got a new continuation time, no detections")
+          continue
+        else:
+          _LOGGER_.info("Got detection batch with continuationTime=%s",
+                        continuation_time)
 
         # Process the batch using the callback.
-        detections = batch["detections"] if "detections" in batch else []
+        detections = batch["detections"]
         process_detection_batch_callback((detections, continuation_time))
 
   return (disconnection_reason, continuation_time)


### PR DESCRIPTION
Currently, the callback will occur even if the batch only contains a continuationTime and no detections, e.g. the below output

```
Batch: {'continuationTime': '2021-01-08T15:23:12.590029867Z'}
First 100 lines of the detection batch dump:
[]
2021-01-08 10:23:27,855:WARNING:stream_detection_alerts:WEBHOOK_URL is not populated, skipping slack webhook integration
```

This PR simplifies the process by keeping the continuation time then continuing if there is no detection array.